### PR TITLE
Replaces "cmp" with "Buffer.compare".

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class TreeNode {
 
     while (s < e) {
       const mid = (s + e) >> 1
-      c = cmp(key.value, await this.getKey(mid))
+      c = Buffer.compare(key.value, await this.getKey(mid))
 
       if (c === 0) {
         if (!overwrite) return true
@@ -529,7 +529,7 @@ class Batch {
       while (s < e) {
         const mid = (s + e) >> 1
 
-        c = cmp(key, await node.getKey(mid))
+        c = Buffer.compare(key, await node.getKey(mid))
 
         if (c === 0) {
           return (await this.getBlock(node.keys[mid].seq)).final()
@@ -571,7 +571,7 @@ class Batch {
 
       while (s < e) {
         const mid = (s + e) >> 1
-        c = cmp(target.value, await node.getKey(mid))
+        c = Buffer.compare(target.value, await node.getKey(mid))
 
         if (c === 0) {
           if (!this.overwrite) return this._unlockMaybe()
@@ -630,7 +630,7 @@ class Batch {
 
       while (s < e) {
         const mid = (s + e) >> 1
-        c = cmp(key, await node.getKey(mid))
+        c = Buffer.compare(key, await node.getKey(mid))
 
         if (c === 0) {
           if (node.children.length) await setKeyToNearestLeaf(node, mid, stack)
@@ -827,10 +827,6 @@ function iteratorToStream (ite, active) {
     rs.push(val)
     done(null)
   }
-}
-
-function cmp (a, b) {
-  return a < b ? -1 : b < a ? 1 : 0
 }
 
 function encRange (e, opts) {

--- a/iterators/diff.js
+++ b/iterators/diff.js
@@ -204,5 +204,5 @@ module.exports = class DiffIterator {
 function cmp (a, b) {
   if (!a) return b ? 1 : 0
   if (!b) return a ? -1 : 0
-  return a < b ? -1 : b < a ? 1 : 0
+  return Buffer.compare(a, b)
 }

--- a/iterators/range.js
+++ b/iterators/range.js
@@ -83,7 +83,7 @@ module.exports = class RangeIterator {
 
       while (s < e) {
         const mid = (s + e) >> 1
-        c = cmp(start, await node.getKey(mid))
+        c = Buffer.compare(start, await node.getKey(mid))
 
         if (c === 0) {
           if (incl) entry.i = mid * 2 + 1
@@ -143,7 +143,7 @@ module.exports = class RangeIterator {
       const key = top.node.keys[n]
       const block = await this.db.getBlock(key.seq)
       if (end) {
-        const c = cmp(block.key, end)
+        const c = Buffer.compare(block.key, end)
         if (c === 0 ? !incl : (this._reverse ? c < 0 : c > 0)) {
           this._limit = 0
           break
@@ -157,8 +157,4 @@ module.exports = class RangeIterator {
     this._nexting = false
     return null
   }
-}
-
-function cmp (a, b) {
-  return a < b ? -1 : b < a ? 1 : 0
 }


### PR DESCRIPTION
When reading over the code I noticed that the `cmp` operation is using `>` instead of `Buffer.compare`. The problem is that these operations are not equal (see [this gist](https://gist.github.com/martinheidegger/3ea2ea920073c9a69f464ff153af27d1)) and it seems that the buffer comparison may be using the `.toString()` value of `Uint8Array`s for comparison? In any case, [I tested the performance](https://jsbench.me/ipkisazwkq/1) for the methods and the result is that `Buffer.compare` is a **lot** faster than `>`. Which is why this PR replaces `cmp` with `Buffer.compare`.

<img width="651" alt="Screen Shot 2020-12-17 at 13 02 45" src="https://user-images.githubusercontent.com/914122/102442621-3121b080-4068-11eb-9593-0047fc6c67a3.png">
